### PR TITLE
Add hint to add ProcessPhoenix to AndroidManifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Usage
 Add the ProcessPhoenix activity to your app's `AndroidManifest.xml`:
 
 ```xml
-<activity android:name="net.core.helper.ProcessPhoenix"/>
+<activity android:name="com.jakewharton.processphoenix.ProcessPhoenix"/>
 ```
 
 Start the default activity in a new process:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ changing from staging to production).
 Usage
 -----
 
+Add the ProcessPhoenix activity to your app's `AndroidManifest.xml`:
+
+```xml
+<activity android:name="net.core.helper.ProcessPhoenix"/>
+```
+
 Start the default activity in a new process:
 ```java
 ProcessPhoenix.triggerRebirth(context);

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -10,6 +10,6 @@
         <category android:name="android.intent.category.DEFAULT"/>
       </intent-filter>
     </activity>
-    <activity android:name="net.core.helper.ProcessPhoenix"/>
+    <activity android:name="com.jakewharton.processphoenix.ProcessPhoenix"/>
   </application>
 </manifest>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -10,5 +10,6 @@
         <category android:name="android.intent.category.DEFAULT"/>
       </intent-filter>
     </activity>
+    <activity android:name="net.core.helper.ProcessPhoenix"/>
   </application>
 </manifest>


### PR DESCRIPTION
Missing adding the ProcessPhoenix Activity to the app's manifest causes a crash which ultimately leads to a restart of the application, but I don't think that that's the way it's intended to work. ;)