### PR TITLE
Bump minSdkVersion to 4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
 }
 
 ext {
-  minSdkVersion = 3
+  minSdkVersion = 4
   compileSdkVersion = 22
   buildToolsVersion = '22.0.1'
 


### PR DESCRIPTION
This prevents the tooling from automatically adding READ_PHONE_STATE to any
app using ProcessPhoenix.

Number nine. Number nine. #9.