### PR TITLE
Delete unnecessary method call.

### DIFF
--- a/process-phoenix/src/main/java/com/jakewharton/processphoenix/ProcessPhoenix.java
+++ b/process-phoenix/src/main/java/com/jakewharton/processphoenix/ProcessPhoenix.java
@@ -91,6 +91,5 @@ public final class ProcessPhoenix extends Activity {
     Intent intent = getIntent().getParcelableExtra(KEY_RESTART_INTENT);
     startActivity(intent);
     finish();
-    Runtime.getRuntime().exit(0); // Kill kill kill!
   }
 }


### PR DESCRIPTION
I guess this `exit` method is unnecessary.
I tested without it with sample app but process id is always changed and other stuff works well.
Any thoughts?