### PR TITLE
Add method to check if current process is the :phoenix process

### DIFF
--- a/process-phoenix/src/main/java/com/jakewharton/processphoenix/ProcessPhoenix.java
+++ b/process-phoenix/src/main/java/com/jakewharton/processphoenix/ProcessPhoenix.java
@@ -24,6 +24,7 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.os.Bundle;
+import android.os.Process;
 
 import static android.content.Intent.ACTION_MAIN;
 import static android.content.Intent.CATEGORY_DEFAULT;
@@ -98,12 +99,12 @@ public final class ProcessPhoenix extends Activity {
   /**
    * Checks if the current process is a temporary Phoenix Process.
    * This can be used to avoid initialisation of unused resources or to prevent running code that
-   * is not multi process ready.
+   * is not multi-process ready.
    *
    * @return true if the current process is a temporary Phoenix Process
    */
   public static boolean isPhoenixProcess(Context context) {
-    int currentPid = android.os.Process.myPid();
+    int currentPid = Process.myPid();
     ActivityManager manager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
     for (ActivityManager.RunningAppProcessInfo processInfo : manager.getRunningAppProcesses()) {
       if (processInfo.pid == currentPid && processInfo.processName.endsWith(":phoenix")) {

--- a/process-phoenix/src/main/java/com/jakewharton/processphoenix/ProcessPhoenix.java
+++ b/process-phoenix/src/main/java/com/jakewharton/processphoenix/ProcessPhoenix.java
@@ -16,6 +16,7 @@
 package com.jakewharton.processphoenix;
 
 import android.app.Activity;
+import android.app.ActivityManager;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -92,5 +93,23 @@ public final class ProcessPhoenix extends Activity {
     startActivity(intent);
     finish();
     Runtime.getRuntime().exit(0); // Kill kill kill!
+  }
+
+  /**
+   * Checks if the current process is a temporary Phoenix Process.
+   * This can be used to avoid initialisation of unused resources or to prevent running code that
+   * is not multi process ready.
+   *
+   * @return true if the current process is a temporary Phoenix Process
+   */
+  public static boolean isPhoenixProcess(Context context) {
+    int currentPid = android.os.Process.myPid();
+    ActivityManager manager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+    for (ActivityManager.RunningAppProcessInfo processInfo : manager.getRunningAppProcesses()) {
+      if (processInfo.pid == currentPid && processInfo.processName.endsWith(":phoenix")) {
+        return true;
+      }
+    }
+    return false;
   }
 }


### PR DESCRIPTION
This is for #14

The implementation relies on iterating through the running processes, I am not sure that this works in past and future device/os combinations. Seems to run alright on my android 6.0.1 device.

If required I can add:
- memoization of the `isPhoenixProcess()` method
- a faster string comparison using by using` BuildConfig.APPLICATION_ID + ":phoenix";`
- an update to the sample app with additional logs inside the activity or even add an Application subclass.

The current PR is minimalistic and aims to reduce code bloat.

