### PR TITLE
Remove outdated information from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,6 @@ Intent nextIntent = //...
 ProcessPhoenix.triggerRebirth(context, nextIntent);
 ```
 
-To check if your application is inside the Phoenix process to skip initialization in `onCreate`:
-```java
-if (ProcessPhoenix.isPhoenixProcess(this)) {
-  return;
-}
-```
-
 
 
 Download


### PR DESCRIPTION
It looks like `ProcessPhoenix.isPhoenixProcess()` is no longer to be found in the library.
Removed it from README to not confuse users of the libary.