### PR TITLE
Fix crash "default activity not found" on android 8 and above

### DIFF
--- a/process-phoenix/src/main/AndroidManifest.xml
+++ b/process-phoenix/src/main/AndroidManifest.xml
@@ -6,7 +6,10 @@
     <activity
         android:name=".ProcessPhoenix"
         android:theme="@android:style/Theme.Translucent.NoTitleBar"
-        android:process=":phoenix"
-        />
+        android:process=":phoenix">
+      <intent-filter>
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+    </activity>
   </application>
 </manifest>


### PR DESCRIPTION
I've added intent filter with default category for PhoenixActivity. Pull request fixes this [issue](https://github.com/JakeWharton/ProcessPhoenix/issues/32#issue-445820490)