### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Download
 --------
 
 ```groovy
-compile 'com.jakewharton:process-phoenix:2.0.0'
+implementation 'com.jakewharton:process-phoenix:2.0.0'
 ```
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].


### PR DESCRIPTION
compile has been deprecated, should be updated to implementation in line with current standards