### PR TITLE
Drag project into 2021 (sort of)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,24 +1,24 @@
 buildscript {
   repositories {
-    jcenter()
+    google()
+    mavenCentral()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.2'
+    classpath 'com.android.tools.build:gradle:4.2.1'
   }
 }
 
 allprojects {
   repositories {
+    google()
     mavenCentral()
   }
 }
 
 ext {
   minSdkVersion = 11
-  compileSdkVersion = 25
-  buildToolsVersion = '25.0.0'
+  compileSdkVersion = 30
+  buildToolsVersion = '30.0.3'
 
-  ci = 'true'.equals(System.getenv('CI'))
-
-  butterKnife = 'com.jakewharton:butterknife:7.0.0'
+  ci = 'true' == System.getenv('CI')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Nov 10 10:49:45 EST 2016
+#Fri Jun 25 11:00:51 AEST 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/process-phoenix/build.gradle
+++ b/process-phoenix/build.gradle
@@ -16,10 +16,9 @@ android {
   dexOptions {
     preDexLibraries = !rootProject.ext.ci
   }
-  
-  // TODO replace with https://issuetracker.google.com/issues/72050365 once released.
-  libraryVariants.all {
-    it.generateBuildConfig.enabled = false
+
+  buildFeatures {
+    buildConfig = false
   }
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,8 +1,7 @@
 apply plugin: 'com.android.application'
 
 dependencies {
-  compile project(':process-phoenix')
-  compile rootProject.ext.butterKnife
+  implementation project(':process-phoenix')
 }
 
 android {

--- a/sample/src/main/java/com/jakewharton/processphoenix/sample/MainActivity.java
+++ b/sample/src/main/java/com/jakewharton/processphoenix/sample/MainActivity.java
@@ -4,35 +4,40 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Process;
+import android.view.View;
 import android.widget.TextView;
-import butterknife.Bind;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
 import com.jakewharton.processphoenix.ProcessPhoenix;
 
 public final class MainActivity extends Activity {
   private static final String EXTRA_TEXT = "text";
 
-  @Bind(R.id.process_id) TextView processIdView;
-  @Bind(R.id.extra_text) TextView extraTextView;
-
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
     setContentView(R.layout.activity_main);
-    ButterKnife.bind(this);
+
+    TextView processIdView = findViewById(R.id.process_id);
+    TextView extraTextView = findViewById(R.id.extra_text);
+    View restartButton = findViewById(R.id.restart);
+    View restartWithIntentButton = findViewById(R.id.restart_with_intent);
 
     processIdView.setText("Process ID: " + Process.myPid());
     extraTextView.setText("Extra Text: " + getIntent().getStringExtra(EXTRA_TEXT));
-  }
 
-  @OnClick(R.id.restart) void restart() {
-    ProcessPhoenix.triggerRebirth(this);
-  }
+    restartButton.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        ProcessPhoenix.triggerRebirth(MainActivity.this);
+      }
+    });
 
-  @OnClick(R.id.restart_with_intent) void restartWithIntent() {
-    Intent nextIntent = new Intent(this, MainActivity.class);
-    nextIntent.putExtra(EXTRA_TEXT, "Hello!");
-    ProcessPhoenix.triggerRebirth(this, nextIntent);
+    restartWithIntentButton.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        Intent nextIntent = new Intent(MainActivity.this, MainActivity.class);
+        nextIntent.putExtra(EXTRA_TEXT, "Hello!");
+        ProcessPhoenix.triggerRebirth(MainActivity.this, nextIntent);
+      }
+    });
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,3 @@
 rootProject.name = 'process-phoenix-root'
 
 include ':process-phoenix', ':sample'
-//include ':sample'


### PR DESCRIPTION
I removed butterknife from the sample app since it didn't seem to play well with the latest build tools. Bumping butterknife or using viewbinding would have involved bumping the repo's minSdk to the lofty heights of API 14, breaking the current support for 11.

So keeping it simple for now.