### PR TITLE
Fix Android 12 compatibility

### DIFF
--- a/process-phoenix/src/main/AndroidManifest.xml
+++ b/process-phoenix/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:name=".ProcessPhoenix"
         android:theme="@android:style/Theme.Translucent.NoTitleBar"
         android:process=":phoenix"
+        android:exported="false"
         />
   </application>
 </manifest>


### PR DESCRIPTION
Starting from Android 12/SDK level 31 ``android:exported`` needs to be explicitly specified. Otherwise apps using this library will fail to compile. https://developer.android.com/about/versions/12/behavior-changes-12#exported

I assume it can be set to ``false``, since the activity is only used within the app using this library. If it should be ``true``, feel free to edit this pull request.

Fixes https://github.com/JakeWharton/ProcessPhoenix/issues/43.