### PR TITLE
Support service processes

### DIFF
--- a/process-phoenix/src/main/AndroidManifest.xml
+++ b/process-phoenix/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 
   <application>
     <activity
-      android:name=".ProcessPhoenix"
+      android:name=".PhoenixActivity"
       android:exported="false"
       android:process=":phoenix"
       android:theme="@android:style/Theme.Translucent.NoTitleBar"

--- a/process-phoenix/src/main/AndroidManifest.xml
+++ b/process-phoenix/src/main/AndroidManifest.xml
@@ -7,5 +7,11 @@
       android:process=":phoenix"
       android:theme="@android:style/Theme.Translucent.NoTitleBar"
       />
+
+    <service
+        android:name=".PhoenixService"
+        android:exported="false"
+        android:process=":phoenix"
+        />
   </application>
 </manifest>

--- a/process-phoenix/src/main/java/com/jakewharton/processphoenix/PhoenixActivity.java
+++ b/process-phoenix/src/main/java/com/jakewharton/processphoenix/PhoenixActivity.java
@@ -14,12 +14,12 @@ public final class PhoenixActivity extends Activity {
     super.onCreate(savedInstanceState);
 
     // Kill original main process
-    Process.killProcess(
-        getIntent().getIntExtra(ProcessPhoenix.KEY_MAIN_PROCESS_PID, -1));
+    Process.killProcess(getIntent().getIntExtra(ProcessPhoenix.KEY_MAIN_PROCESS_PID, -1));
 
-    Intent[] intents = getIntent()
-        .<Intent>getParcelableArrayListExtra(ProcessPhoenix.KEY_RESTART_INTENTS)
-        .toArray(new Intent[0]);
+    Intent[] intents =
+        getIntent()
+            .<Intent>getParcelableArrayListExtra(ProcessPhoenix.KEY_RESTART_INTENTS)
+            .toArray(new Intent[0]);
 
     if (Build.VERSION.SDK_INT > 31) {
       // Disable strict mode complaining about out-of-process intents. Normally you save and restore

--- a/process-phoenix/src/main/java/com/jakewharton/processphoenix/PhoenixActivity.java
+++ b/process-phoenix/src/main/java/com/jakewharton/processphoenix/PhoenixActivity.java
@@ -1,0 +1,33 @@
+package com.jakewharton.processphoenix;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Process;
+import android.os.StrictMode;
+
+public class PhoenixActivity extends Activity {
+   @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    Process.killProcess(getIntent().getIntExtra(ProcessPhoenix.KEY_MAIN_PROCESS_PID, -1)); // Kill original main process
+
+    Intent[] intents = getIntent()
+        .<Intent>getParcelableArrayListExtra(ProcessPhoenix.KEY_RESTART_INTENTS)
+        .toArray(new Intent[0]);
+
+    if (Build.VERSION.SDK_INT > 31) {
+      // Disable strict mode complaining about out-of-process intents. Normally you save and restore
+      // the original policy, but this process will die almost immediately after the offending call.
+      StrictMode.setVmPolicy(
+          new StrictMode.VmPolicy.Builder(StrictMode.getVmPolicy())
+              .permitUnsafeIntentLaunch()
+              .build());
+    }
+
+    startActivities(intents);
+    finish();
+    Runtime.getRuntime().exit(0); // Kill kill kill!
+  }
+}

--- a/process-phoenix/src/main/java/com/jakewharton/processphoenix/PhoenixActivity.java
+++ b/process-phoenix/src/main/java/com/jakewharton/processphoenix/PhoenixActivity.java
@@ -7,7 +7,7 @@ import android.os.Bundle;
 import android.os.Process;
 import android.os.StrictMode;
 
-public class PhoenixActivity extends Activity {
+public final class PhoenixActivity extends Activity {
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {

--- a/process-phoenix/src/main/java/com/jakewharton/processphoenix/PhoenixActivity.java
+++ b/process-phoenix/src/main/java/com/jakewharton/processphoenix/PhoenixActivity.java
@@ -8,7 +8,9 @@ import android.os.Process;
 import android.os.StrictMode;
 
 public class PhoenixActivity extends Activity {
-   @Override protected void onCreate(Bundle savedInstanceState) {
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
     Process.killProcess(getIntent().getIntExtra(ProcessPhoenix.KEY_MAIN_PROCESS_PID, -1)); // Kill original main process

--- a/process-phoenix/src/main/java/com/jakewharton/processphoenix/PhoenixService.java
+++ b/process-phoenix/src/main/java/com/jakewharton/processphoenix/PhoenixService.java
@@ -25,7 +25,8 @@ public final class PhoenixService extends IntentService {
       return;
     }
 
-    Process.killProcess(intent.getIntExtra(ProcessPhoenix.KEY_MAIN_PROCESS_PID, -1)); // Kill original main process
+    Process.killProcess(
+        intent.getIntExtra(ProcessPhoenix.KEY_MAIN_PROCESS_PID, -1)); // Kill original main process
 
     Intent nextIntent;
     if (Build.VERSION.SDK_INT >= 33) {

--- a/process-phoenix/src/main/java/com/jakewharton/processphoenix/PhoenixService.java
+++ b/process-phoenix/src/main/java/com/jakewharton/processphoenix/PhoenixService.java
@@ -13,7 +13,7 @@ import android.os.StrictMode;
  * The observed delay periods are: 1s, 4s, 16s, 64s, 256s, 1024s. (on an Android 11 device)
  * Which seems to follow this pattern: 4^x, with x being the restart attempt minus 1.
  */
-public class PhoenixService extends IntentService {
+public final class PhoenixService extends IntentService {
 
   public PhoenixService() {
     super("PhoenixService");

--- a/process-phoenix/src/main/java/com/jakewharton/processphoenix/PhoenixService.java
+++ b/process-phoenix/src/main/java/com/jakewharton/processphoenix/PhoenixService.java
@@ -1,0 +1,54 @@
+package com.jakewharton.processphoenix;
+
+import android.app.IntentService;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Process;
+import android.os.StrictMode;
+
+/**
+ * Please note that restarting a Service multiple times can result in an increasingly long delay between restart times.
+ * This is a safety mechanism, since Android registers the restart of this service as a crashed service.
+ * <p>
+ * The observed delay periods are: 1s, 4s, 16s, 64s, 256s, 1024s. (on an Android 11 device)
+ * Which seems to follow this pattern: 4^x, with x being the restart attempt minus 1.
+ */
+public class PhoenixService extends IntentService {
+
+  public PhoenixService() {
+    super("PhoenixService");
+  }
+
+  @Override
+  protected void onHandleIntent(Intent intent) {
+    if (intent == null) {
+      return;
+    }
+
+    Process.killProcess(intent.getIntExtra(ProcessPhoenix.KEY_MAIN_PROCESS_PID, -1)); // Kill original main process
+
+    Intent nextIntent;
+    if (Build.VERSION.SDK_INT >= 33) {
+      nextIntent = intent.getParcelableExtra(ProcessPhoenix.KEY_RESTART_INTENT, Intent.class);
+    } else {
+      nextIntent = intent.getParcelableExtra(ProcessPhoenix.KEY_RESTART_INTENT);
+    }
+
+    if (Build.VERSION.SDK_INT > 31) {
+      // Disable strict mode complaining about out-of-process intents. Normally you save and restore
+      // the original policy, but this process will die almost immediately after the offending call.
+      StrictMode.setVmPolicy(
+          new StrictMode.VmPolicy.Builder(StrictMode.getVmPolicy())
+              .permitUnsafeIntentLaunch()
+              .build());
+    }
+
+    if (Build.VERSION.SDK_INT >= 26) {
+      startForegroundService(nextIntent);
+    } else {
+      startService(nextIntent);
+    }
+
+    Runtime.getRuntime().exit(0); // Kill kill kill!
+  }
+}

--- a/process-phoenix/src/main/java/com/jakewharton/processphoenix/ProcessPhoenix.java
+++ b/process-phoenix/src/main/java/com/jakewharton/processphoenix/ProcessPhoenix.java
@@ -39,9 +39,9 @@ import static android.content.pm.PackageManager.FEATURE_LEANBACK;
  * <p>
  * Trigger process recreation by calling {@link #triggerRebirth} with a {@link Context} instance.
  */
-public final class ProcessPhoenix extends Activity {
-  private static final String KEY_RESTART_INTENTS = "phoenix_restart_intents";
-  private static final String KEY_MAIN_PROCESS_PID = "phoenix_main_process_pid";
+public final class ProcessPhoenix {
+  static final String KEY_RESTART_INTENTS = "phoenix_restart_intents";
+  static final String KEY_MAIN_PROCESS_PID = "phoenix_main_process_pid";
 
   /**
    * Call to restart the application process using the {@linkplain Intent#CATEGORY_DEFAULT default}
@@ -65,7 +65,7 @@ public final class ProcessPhoenix extends Activity {
     // create a new task for the first activity.
     nextIntents[0].addFlags(FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TASK);
 
-    Intent intent = new Intent(context, ProcessPhoenix.class);
+    Intent intent = new Intent(context, PhoenixActivity.class);
     intent.addFlags(FLAG_ACTIVITY_NEW_TASK); // In case we are called with non-Activity context.
     intent.putParcelableArrayListExtra(KEY_RESTART_INTENTS, new ArrayList<>(Arrays.asList(nextIntents)));
     intent.putExtra(KEY_MAIN_PROCESS_PID, Process.myPid());
@@ -91,29 +91,6 @@ public final class ProcessPhoenix extends Activity {
     throw new IllegalStateException("Unable to determine default activity for "
         + packageName
         + ". Does an activity specify the DEFAULT category in its intent filter?");
-  }
-
-  @Override protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-
-    Process.killProcess(getIntent().getIntExtra(KEY_MAIN_PROCESS_PID, -1)); // Kill original main process
-
-    Intent[] intents = getIntent()
-        .<Intent>getParcelableArrayListExtra(KEY_RESTART_INTENTS)
-        .toArray(new Intent[0]);
-
-    if (Build.VERSION.SDK_INT > 31) {
-      // Disable strict mode complaining about out-of-process intents. Normally you save and restore
-      // the original policy, but this process will die almost immediately after the offending call.
-      StrictMode.setVmPolicy(
-          new StrictMode.VmPolicy.Builder(StrictMode.getVmPolicy())
-              .permitUnsafeIntentLaunch()
-              .build());
-    }
-
-    startActivities(intents);
-    finish();
-    Runtime.getRuntime().exit(0); // Kill kill kill!
   }
 
   /**

--- a/process-phoenix/src/main/java/com/jakewharton/processphoenix/ProcessPhoenix.java
+++ b/process-phoenix/src/main/java/com/jakewharton/processphoenix/ProcessPhoenix.java
@@ -22,9 +22,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.os.Bundle;
 import android.os.Process;
-import android.os.StrictMode;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -56,56 +55,21 @@ public final class ProcessPhoenix {
   }
 
   /**
-   * Call to restart the application process using the provided targetClass as an intent.
+   * Call to restart the application process using the provided Activity Class.
    * <p>
    * Behavior of the current process after invoking this method is undefined.
    */
-  public static void triggerRebirth(Context context, Class<?> targetClass) {
+  public static void triggerRebirth(Context context, Class<? extends Activity> targetClass) {
     Intent nextIntent = new Intent(context, targetClass);
-
-    if (Service.class.isAssignableFrom(targetClass)) {
-      triggerServiceRebirth(context, nextIntent);
-      return;
-    }
-
-    // Default to Activity rebirth
-    triggerActivityRebirth(context, nextIntent);
+    triggerRebirth(context, nextIntent);
   }
 
   /**
    * Call to restart the application process using the specified intents.
-   * Please note: If the intents resolves to a Service only the first intent is used.
    * <p>
    * Behavior of the current process after invoking this method is undefined.
    */
   public static void triggerRebirth(Context context, Intent... nextIntents) {
-    if (nextIntents.length < 1) {
-      throw new IllegalArgumentException("intents cannot be empty");
-    }
-
-    Intent firstIntent = nextIntents[0];
-    PackageManager pm = context.getPackageManager();
-
-    if (pm.resolveActivity(firstIntent, 0) != null) {
-      triggerActivityRebirth(context, nextIntents);
-      return;
-    }
-
-    if (pm.resolveService(firstIntent, 0) != null) {
-      triggerServiceRebirth(context, firstIntent);
-      return;
-    }
-
-    // If the first intent does not resolve to an Activity or Service, default to Activity rebirth
-    triggerActivityRebirth(context, nextIntents);
-  }
-
-  /**
-   * Call to restart the application process using the specified intents.
-   * <p>
-   * Behavior of the current process after invoking this method is undefined.
-   */
-  public static void triggerActivityRebirth(Context context, Intent... nextIntents) {
     if (nextIntents.length < 1) {
       throw new IllegalArgumentException("intents cannot be empty");
     }
@@ -119,6 +83,15 @@ public final class ProcessPhoenix {
     context.startActivity(intent);
   }
 
+  /**
+   * Call to restart the application process using the provided Service Class.
+   * <p>
+   * Behavior of the current process after invoking this method is undefined.
+   */
+  public static void triggerServiceRebirth(Context context, Class<? extends Service> targetClass) {
+    Intent nextIntent = new Intent(context, targetClass);
+    triggerServiceRebirth(context, nextIntent);
+  }
 
   /**
    * Call to restart the application process using the specified Service intent.

--- a/process-phoenix/src/main/java/com/jakewharton/processphoenix/ProcessPhoenix.java
+++ b/process-phoenix/src/main/java/com/jakewharton/processphoenix/ProcessPhoenix.java
@@ -27,7 +27,6 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Process;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
     <service
       android:name=".RestartService"
       android:exported="true"
-      android:foregroundServiceType="shortService" />
+      android:foregroundServiceType="shortService"
+      />
   </application>
 </manifest>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
   xmlns:tools="http://schemas.android.com/tools"
   >
 
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
   <application
     android:label="Process Phoenix"
     tools:ignore="MissingApplicationIcon"
@@ -18,5 +21,11 @@
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
     </activity>
+
+
+    <service
+      android:name=".RestartService"
+      android:exported="true"
+      android:foregroundServiceType="shortService" />
   </application>
 </manifest>

--- a/sample/src/main/java/com/jakewharton/processphoenix/sample/MainActivity.java
+++ b/sample/src/main/java/com/jakewharton/processphoenix/sample/MainActivity.java
@@ -2,6 +2,7 @@ package com.jakewharton.processphoenix.sample;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Process;
 import android.view.View;
@@ -20,6 +21,8 @@ public final class MainActivity extends Activity {
     TextView extraTextView = findViewById(R.id.extra_text);
     View restartButton = findViewById(R.id.restart);
     View restartWithIntentButton = findViewById(R.id.restart_with_intent);
+    View restartActivityButton = findViewById(R.id.restartActivity);
+    View restartServiceButton = findViewById(R.id.restart_service);
 
     processIdView.setText("Process ID: " + Process.myPid());
     extraTextView.setText("Extra Text: " + getIntent().getStringExtra(EXTRA_TEXT));
@@ -37,6 +40,28 @@ public final class MainActivity extends Activity {
         Intent nextIntent = new Intent(MainActivity.this, MainActivity.class);
         nextIntent.putExtra(EXTRA_TEXT, "Hello!");
         ProcessPhoenix.triggerRebirth(MainActivity.this, nextIntent);
+      }
+    });
+
+    restartActivityButton.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        ProcessPhoenix.triggerRebirth(MainActivity.this, MainActivity.class);
+      }
+    });
+
+    restartServiceButton.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        // Start the RestartService, which initiates the service restart cycle.
+        // TODO: Request permissions when the API level is high enough to require FOREGROUND_SERVICE or POST_NOTIFICATIONS
+        Intent restartServiceIntent = new Intent(MainActivity.this, RestartService.class);
+        if (Build.VERSION.SDK_INT >= 26) {
+          startForegroundService(restartServiceIntent);
+        } else {
+          startService(restartServiceIntent);
+        }
+        finish();
       }
     });
   }

--- a/sample/src/main/java/com/jakewharton/processphoenix/sample/NotificationBuilder.java
+++ b/sample/src/main/java/com/jakewharton/processphoenix/sample/NotificationBuilder.java
@@ -10,7 +10,7 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.util.Log;
 
-public class NotificationBuilder {
+public final class NotificationBuilder {
 
     /**
      * Create a Notification, required to support Service restarting on Android 8 and newer

--- a/sample/src/main/java/com/jakewharton/processphoenix/sample/NotificationBuilder.java
+++ b/sample/src/main/java/com/jakewharton/processphoenix/sample/NotificationBuilder.java
@@ -1,0 +1,52 @@
+package com.jakewharton.processphoenix.sample;
+
+import android.Manifest;
+import android.annotation.TargetApi;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.util.Log;
+
+public class NotificationBuilder {
+
+    /**
+     * Create a Notification, required to support Service restarting on Android 8 and newer
+     */
+    @TargetApi(26)
+    public static Notification createNotification(Context context) {
+        // Android 13 or higher requires a permission to post Notifications
+        if (Build.VERSION.SDK_INT >= 33) {
+            if (context.checkCallingOrSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+                Log.e(
+                        "ProcessPhoenix",
+                        "Required POST_NOTIFICATIONS permission was not granted, cannot restart Service"
+                );
+                return null;
+            }
+        }
+
+        // Android 8 or higher requires a Notification Channel
+        if (Build.VERSION.SDK_INT >= 26) {
+            // Creating an existing notification channel with its original values performs no operation, so it's safe to call this code multiple times
+            NotificationChannel channel = new NotificationChannel(
+                    "ProcessPhoenix",
+                    "ProcessPhoenix",
+                    NotificationManager.IMPORTANCE_NONE
+            );
+
+            // Create Notification Channel
+            NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+            notificationManager.createNotificationChannel(channel);
+        }
+
+        // Create a Notification
+        return new Notification.Builder(context, "ProcessPhoenix")
+                .setSmallIcon(android.R.mipmap.sym_def_app_icon)
+                .setContentTitle("ProcessPhoenix")
+                .setContentText("PhoenixService")
+                .build();
+    }
+}

--- a/sample/src/main/java/com/jakewharton/processphoenix/sample/NotificationBuilder.java
+++ b/sample/src/main/java/com/jakewharton/processphoenix/sample/NotificationBuilder.java
@@ -12,41 +12,41 @@ import android.util.Log;
 
 public final class NotificationBuilder {
 
-    /**
-     * Create a Notification, required to support Service restarting on Android 8 and newer
-     */
-    @TargetApi(26)
-    public static Notification createNotification(Context context) {
-        // Android 13 or higher requires a permission to post Notifications
-        if (Build.VERSION.SDK_INT >= 33) {
-            if (context.checkCallingOrSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
-                Log.e(
-                        "ProcessPhoenix",
-                        "Required POST_NOTIFICATIONS permission was not granted, cannot restart Service"
-                );
-                return null;
-            }
-        }
-
-        // Android 8 or higher requires a Notification Channel
-        if (Build.VERSION.SDK_INT >= 26) {
-            // Creating an existing notification channel with its original values performs no operation, so it's safe to call this code multiple times
-            NotificationChannel channel = new NotificationChannel(
-                    "ProcessPhoenix",
-                    "ProcessPhoenix",
-                    NotificationManager.IMPORTANCE_NONE
-            );
-
-            // Create Notification Channel
-            NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-            notificationManager.createNotificationChannel(channel);
-        }
-
-        // Create a Notification
-        return new Notification.Builder(context, "ProcessPhoenix")
-                .setSmallIcon(android.R.mipmap.sym_def_app_icon)
-                .setContentTitle("ProcessPhoenix")
-                .setContentText("PhoenixService")
-                .build();
+  /**
+   * Create a Notification, required to support Service restarting on Android 8 and newer
+   */
+  @TargetApi(26)
+  public static Notification createNotification(Context context) {
+    // Android 13 or higher requires a permission to post Notifications
+    if (Build.VERSION.SDK_INT >= 33) {
+      if (context.checkCallingOrSelfPermission(Manifest.permission.POST_NOTIFICATIONS)
+          != PackageManager.PERMISSION_GRANTED) {
+        Log.e(
+            "ProcessPhoenix",
+            "Required POST_NOTIFICATIONS permission was not granted, cannot restart Service");
+        return null;
+      }
     }
+
+    // Android 8 or higher requires a Notification Channel
+    if (Build.VERSION.SDK_INT >= 26) {
+      // Creating an existing notification channel with its original values performs no operation,
+      // so it's safe to call this code multiple times
+      NotificationChannel channel =
+          new NotificationChannel(
+              "ProcessPhoenix", "ProcessPhoenix", NotificationManager.IMPORTANCE_NONE);
+
+      // Create Notification Channel
+      NotificationManager notificationManager =
+          (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+      notificationManager.createNotificationChannel(channel);
+    }
+
+    // Create a Notification
+    return new Notification.Builder(context, "ProcessPhoenix")
+        .setSmallIcon(android.R.mipmap.sym_def_app_icon)
+        .setContentTitle("ProcessPhoenix")
+        .setContentText("PhoenixService")
+        .build();
+  }
 }

--- a/sample/src/main/java/com/jakewharton/processphoenix/sample/RestartService.java
+++ b/sample/src/main/java/com/jakewharton/processphoenix/sample/RestartService.java
@@ -20,7 +20,7 @@ import java.util.concurrent.Executors;
  * The observed delay periods are: 1s, 4s, 16s, 64s, 256s, 1024s. (on an Android 11 device)
  * Which seems to follow this pattern: 4^x, with x being the restart attempt minus 1.
  */
-public class RestartService extends IntentService {
+public final class RestartService extends IntentService {
 
     public RestartService() {
         super("RestartService");
@@ -42,11 +42,7 @@ public class RestartService extends IntentService {
         // Trigger rebirth from a separate thread, such that the onStartCommand can finish properly
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.execute(() -> {
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-                // Ignore
-            }
+            SystemClock.sleep(1000)
             ProcessPhoenix.triggerRebirth(RestartService.this, RestartService.class);
 //            ProcessPhoenix.triggerRebirth(RestartService.this, new Intent(RestartService.this, RestartService.class));
         });

--- a/sample/src/main/java/com/jakewharton/processphoenix/sample/RestartService.java
+++ b/sample/src/main/java/com/jakewharton/processphoenix/sample/RestartService.java
@@ -8,7 +8,6 @@ import android.os.Process;
 import android.os.SystemClock;
 import android.util.Log;
 import com.jakewharton.processphoenix.ProcessPhoenix;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -23,29 +22,28 @@ import java.util.concurrent.Executors;
  */
 public final class RestartService extends IntentService {
 
-    public RestartService() {
-        super("RestartService");
+  public RestartService() {
+    super("RestartService");
+  }
+
+  @SuppressLint("ForegroundServiceType")
+  @Override
+  protected void onHandleIntent(Intent intent) {
+    // Log something to console to easily track successful restarts
+    Log.d("ProcessPhoenix", "--- RestartService started with PID: " + Process.myPid() + " ---");
+
+    if (Build.VERSION.SDK_INT >= 26) {
+      startForeground(1337, NotificationBuilder.createNotification(RestartService.this));
     }
 
-    @SuppressLint("ForegroundServiceType")
-    @Override
-    protected void onHandleIntent(Intent intent) {
-        // Log something to console to easily track successful restarts
-        Log.d(
-                "ProcessPhoenix",
-                "--- RestartService started with PID: " + Process.myPid() + " ---"
-        );
-
-        if (Build.VERSION.SDK_INT >= 26) {
-            startForeground(1337, NotificationBuilder.createNotification(RestartService.this));
-        }
-
-        // Trigger rebirth from a separate thread, such that the onStartCommand can finish properly
-        ExecutorService executorService = Executors.newSingleThreadExecutor();
-        executorService.execute(() -> {
-            SystemClock.sleep(1000);
-            ProcessPhoenix.triggerServiceRebirth(RestartService.this, RestartService.class);
-//            ProcessPhoenix.triggerServiceRebirth(RestartService.this, new Intent(RestartService.this, RestartService.class));
+    // Trigger rebirth from a separate thread, such that the onStartCommand can finish properly
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+    executorService.execute(
+        () -> {
+          SystemClock.sleep(1000);
+          ProcessPhoenix.triggerServiceRebirth(RestartService.this, RestartService.class);
+          //            ProcessPhoenix.triggerServiceRebirth(RestartService.this, new
+          // Intent(RestartService.this, RestartService.class));
         });
-    }
+  }
 }

--- a/sample/src/main/java/com/jakewharton/processphoenix/sample/RestartService.java
+++ b/sample/src/main/java/com/jakewharton/processphoenix/sample/RestartService.java
@@ -5,6 +5,7 @@ import android.app.IntentService;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Process;
+import android.os.SystemClock;
 import android.util.Log;
 import com.jakewharton.processphoenix.ProcessPhoenix;
 
@@ -42,9 +43,9 @@ public final class RestartService extends IntentService {
         // Trigger rebirth from a separate thread, such that the onStartCommand can finish properly
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.execute(() -> {
-            SystemClock.sleep(1000)
-            ProcessPhoenix.triggerRebirth(RestartService.this, RestartService.class);
-//            ProcessPhoenix.triggerRebirth(RestartService.this, new Intent(RestartService.this, RestartService.class));
+            SystemClock.sleep(1000);
+            ProcessPhoenix.triggerServiceRebirth(RestartService.this, RestartService.class);
+//            ProcessPhoenix.triggerServiceRebirth(RestartService.this, new Intent(RestartService.this, RestartService.class));
         });
     }
 }

--- a/sample/src/main/java/com/jakewharton/processphoenix/sample/RestartService.java
+++ b/sample/src/main/java/com/jakewharton/processphoenix/sample/RestartService.java
@@ -1,0 +1,54 @@
+package com.jakewharton.processphoenix.sample;
+
+import android.annotation.SuppressLint;
+import android.app.IntentService;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Process;
+import android.util.Log;
+import com.jakewharton.processphoenix.ProcessPhoenix;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * This example service will attempt to restart after 1 second
+ * <p>
+ * Please note that restarting a Service multiple times can result in an increasingly long delay between restart times.
+ * This is a safety mechanism, since Android registers the restart of this service as a crashed service.
+ * <p>
+ * The observed delay periods are: 1s, 4s, 16s, 64s, 256s, 1024s. (on an Android 11 device)
+ * Which seems to follow this pattern: 4^x, with x being the restart attempt minus 1.
+ */
+public class RestartService extends IntentService {
+
+    public RestartService() {
+        super("RestartService");
+    }
+
+    @SuppressLint("ForegroundServiceType")
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        // Log something to console to easily track successful restarts
+        Log.d(
+                "ProcessPhoenix",
+                "--- RestartService started with PID: " + Process.myPid() + " ---"
+        );
+
+        if (Build.VERSION.SDK_INT >= 26) {
+            startForeground(1337, NotificationBuilder.createNotification(RestartService.this));
+        }
+
+        // Trigger rebirth from a separate thread, such that the onStartCommand can finish properly
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.execute(() -> {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                // Ignore
+            }
+            ProcessPhoenix.triggerRebirth(RestartService.this, RestartService.class);
+//            ProcessPhoenix.triggerRebirth(RestartService.this, new Intent(RestartService.this, RestartService.class));
+        });
+    }
+}

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -30,7 +30,7 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginTop="32dp"
-      android:text="Restart Process"
+      android:text="Restart Process with default app launch intent"
       />
 
   <Button
@@ -39,6 +39,22 @@
       android:layout_height="wrap_content"
       android:layout_marginTop="8dp"
       android:text="Restart Process with Intent"
+      />
+
+  <Button
+      android:id="@+id/restartActivity"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="8dp"
+      android:text="Restart Process with MainActivity Class"
+      />
+
+  <Button
+      android:id="@+id/restart_service"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="8dp"
+      android:text="Stop Activity and start service restart loop"
       />
 
 </LinearLayout>


### PR DESCRIPTION
Fixes #24 

What was done per commit:
1. Move the PhoenixActivity code into a separate (Kotlin) class.
2. Migrate ProcessPhoenix class to Kotlin.
3. Add triggerRebirth(Context, Class<?>) with Service rebirth support and triggerServiceRebirth(Context, Intent).
4. Change from Service to IntentService and remove NotificationBuilder from library.
5. Some cleanup.
6. Added Service support to the existing triggerRebirth(context, vararg nextIntents) function.

The ProcessPhoenix class is now Kotlin, but all public functions are annotated with @JvmStatic.
If this is undesired I can implement it in Java, but since Kotlin is my preference I started like this.

I changed from Service to IntentService (in commit 4) because this also seemed to be functional and IntentService's are meant to be short-lived, which the PhoenixService certainly is.

The sample has been updated to allow a easy test of this functionality.

**One important side-node (which is also mentioned in the Service classes):**
Restarting a Service multiple times will result in an increasingly long delay between restart times. Android seems to register the restart of this service as a crashed service and probably doesn't want to infinitely restart a crashing service, so that makes sense.
The increasing delay periods seem to follow the pattern: 4^x, with x being the restart attempt minus 1. I observed 1s, 4s, 16s, 64s, 256s and 1024s on the Zebra Android 11 device i used to test.