### PR TITLE
Disable AGP using its bundled Dokka

### DIFF
--- a/process-phoenix/build.gradle
+++ b/process-phoenix/build.gradle
@@ -9,3 +9,8 @@ android {
     compileSdk rootProject.ext.compileSdkVersion
   }
 }
+
+mavenPublishing.configureBasedOnAppliedPlugins(
+    /* sourceJar = */ true,
+    /* javadocJar = */ false,
+)


### PR DESCRIPTION
It doesn't work on Java 25.